### PR TITLE
Fix type error

### DIFF
--- a/pip_versions/cli.py
+++ b/pip_versions/cli.py
@@ -13,13 +13,13 @@ class Versions(Cliar):
     def list(self, package_name: str, include_pre: bool = False):
         """List the versions available to a package"""
         versions = find_versions(package_name, include_pre)
-        for v in sorted(set(v.version for v in versions)):
+        for v in sorted(set(versions)):
             print(v)
 
     def latest(self, package_name: str, include_pre: bool = False):
         """Show the latest version of a package"""
         versions = find_versions(package_name, include_pre)
-        print(sorted(versions)[-1].version)
+        print(sorted(versions)[-1])
 
 
 def entry_point():

--- a/pip_versions/cli.py
+++ b/pip_versions/cli.py
@@ -26,5 +26,5 @@ def entry_point():
     Versions().parse()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     entry_point()

--- a/pip_versions/core.py
+++ b/pip_versions/core.py
@@ -16,4 +16,4 @@ def find_versions(package_name: str, include_pre: bool = False):
     for candidate in candidates:
         if not include_pre and candidate.version.pre:
             continue
-        yield candidate
+        yield candidate.version


### PR DESCRIPTION
This fixes a type error introduced by a new version of pip (pip 24.x)

```
Traceback (most recent call last):
  File "/usr/local/bin/pip-versions", line 8, in <module>
    sys.exit(entry_point())
             ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pip_versions/cli.py", line 26, in entry_point
    Versions().parse()
  File "/usr/local/lib/python3.12/site-packages/cliar/cliar.py", line 295, in parse
    result = command.handler(**handler_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pip_versions/cli.py", line 22, in latest
    print(sorted(versions)[-1].version)
          ^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'InstallationCandidate' and 'InstallationCandidate'
Traceback (most recent call last):
  File "/usr/local/bin/pip-versions", line 8, in <module>
    sys.exit(entry_point())
             ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pip_versions/cli.py", line 26, in entry_point
    Versions().parse()
  File "/usr/local/lib/python3.12/site-packages/cliar/cliar.py", line 295, in parse
    result = command.handler(**handler_args)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/pip_versions/cli.py", line 22, in latest
    print(sorted(versions)[-1].version)
          ^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'InstallationCandidate' and 'InstallationCandidate'
```